### PR TITLE
feat: put user guards around reminder endpoints

### DIFF
--- a/prisma/migrations/20220131073327_message_add_tries_next_send/migration.sql
+++ b/prisma/migrations/20220131073327_message_add_tries_next_send/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `updatedAt` on the `Message` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Message" DROP COLUMN "updatedAt",
+ADD COLUMN     "nextSend" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "tries" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20220201051249_add_message_active_status/migration.sql
+++ b/prisma/migrations/20220201051249_add_message_active_status/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT false,
+ALTER COLUMN "tries" SET DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,5 +37,6 @@ model Message {
   reminder   Reminder @relation(fields: [reminderId], references: [id])
   reminderId String   @unique
   createdAt  DateTime @default(now()) @db.Timestamptz(6)
-  updatedAt  DateTime @default(now()) @db.Timestamptz(6) // "2022-01-11T07:20:49.271Z"
+  nextSend   DateTime @default(now()) @db.Timestamptz(6) // "2022-01-11T07:20:49.271Z"
+  tries      Int      @default(0)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,5 +38,6 @@ model Message {
   reminderId String   @unique
   createdAt  DateTime @default(now()) @db.Timestamptz(6)
   nextSend   DateTime @default(now()) @db.Timestamptz(6) // "2022-01-11T07:20:49.271Z"
-  tries      Int      @default(0)
+  tries      Int      @default(1)
+  active     Boolean  @default(false)
 }

--- a/src/message/message.controller.ts
+++ b/src/message/message.controller.ts
@@ -1,30 +1,9 @@
-import {
-  Controller,
-  Header,
-  Post,
-  Req,
-  Patch,
-  Param,
-  Body,
-  Delete,
-  Get,
-} from '@nestjs/common'
+import { Controller, Header, Post, Req } from '@nestjs/common'
 import { MessageService } from './message.service'
-import { Prisma } from '@prisma/client'
 
 @Controller('message')
 export class MessageController {
   constructor(private readonly messageService: MessageService) {}
-  //Todo: delete after testing
-  @Get()
-  findAll() {
-    return this.messageService.findAll()
-  }
-
-  @Get('id')
-  findOne(@Param('id') id: string) {
-    return this.messageService.findOne({ id })
-  }
 
   @Post()
   sendMessage(reminderId: string) {
@@ -35,18 +14,5 @@ export class MessageController {
   @Header('Content-Type', 'text/xml')
   receiveMessage(@Req() req) {
     return this.messageService.receiveMessage(req)
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() data: Prisma.MessageUpdateInput) {
-    return this.messageService.update({
-      where: { id },
-      data,
-    })
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.messageService.remove({ id })
   }
 }

--- a/src/message/message.controller.ts
+++ b/src/message/message.controller.ts
@@ -21,6 +21,11 @@ export class MessageController {
     return this.messageService.findAll()
   }
 
+  @Get('id')
+  findOne(@Param('id') id: string) {
+    return this.messageService.findOne({ id })
+  }
+
   @Post()
   sendMessage(reminderId: string) {
     return this.messageService.sendMessage(reminderId)

--- a/src/message/message.module.ts
+++ b/src/message/message.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common'
 import { MessageService } from './message.service'
 import { MessageController } from './message.controller'
 import { DatabaseModule } from '../database/database.module'
-import { TwilioModule } from 'src/twilio/twilio.module'
+import { TwilioModule } from '../twilio/twilio.module'
 
 @Module({
   imports: [DatabaseModule, TwilioModule],

--- a/src/message/message.service.ts
+++ b/src/message/message.service.ts
@@ -3,7 +3,7 @@ import { Cron, CronExpression } from '@nestjs/schedule'
 
 import { Message, Prisma } from '@prisma/client'
 import { DatabaseService } from '../database/database.service'
-import { TwilioService } from 'src/twilio/twilio.service'
+import { TwilioService } from '../twilio/twilio.service'
 import { getNotificationTime, getNextSendTime } from 'utils'
 
 @Injectable()

--- a/src/message/message.service.ts
+++ b/src/message/message.service.ts
@@ -68,7 +68,7 @@ export class MessageService {
   }
 
   async receiveMessage(req) {
-    let pokeResponse = `We'll give you another poke in an hour!`
+    let pokeResponse = `We'll give you another poke in a bit!`
     const userResponse = req.body.Body.trim()
     const user = await this.db.user.findUnique({
       where: { phone: req.body.From },
@@ -127,11 +127,14 @@ export class MessageService {
       })
     })
 
-    // Delete message if more than 3 hours
+    const sixHoursAgo = new Date()
+    sixHoursAgo.setHours(sixHoursAgo.getHours() - 6)
+
+    // Delete message if more than 6 hours
     const expiredMessages = await this.db.message.findMany({
       where: {
-        updatedAt: {
-          gt: reminderThreeHoursAgo,
+        createdAt: {
+          lt: sixHoursAgo,
         },
       },
     })
@@ -141,3 +144,9 @@ export class MessageService {
     })
   }
 }
+// created   updated
+// 4 : 4:01, 5:02, 7:02
+// 5 : 5   6  8  11
+
+// 7
+// cannot match exact time

--- a/src/reminders/reminders.controller.ts
+++ b/src/reminders/reminders.controller.ts
@@ -18,13 +18,13 @@ export class RemindersController {
   constructor(private readonly remindersService: RemindersService) {}
 
   @Get()
-  findAll() {
-    return this.remindersService.findAll()
+  findAll(@CurrentUser() user: AuthUser) {
+    return this.remindersService.findAll(user.id)
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.remindersService.findOne({ id })
+  findOne(@CurrentUser() user: AuthUser, @Param('id') id: string) {
+    return this.remindersService.findOne({ id }, user.id)
   }
 
   @Post()
@@ -36,15 +36,20 @@ export class RemindersController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() data: Prisma.ReminderUpdateInput) {
+  update(
+    @CurrentUser() user: AuthUser,
+    @Param('id') id: string,
+    @Body() data: Prisma.ReminderUpdateInput
+  ) {
     return this.remindersService.update({
       where: { id },
       data,
+      userId: user.id,
     })
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.remindersService.remove({ id })
+  remove(@CurrentUser() user: AuthUser, @Param('id') id: string) {
+    return this.remindersService.remove({ id }, user.id)
   }
 }

--- a/src/reminders/reminders.service.ts
+++ b/src/reminders/reminders.service.ts
@@ -17,13 +17,13 @@ export class RemindersService {
   ) {}
 
   async create(user, data: Prisma.ReminderCreateInput): Promise<Reminder> {
-    const allUserReminders = await this.db.reminder.count({
+    const reminderCount = await this.db.reminder.count({
       where: {
         user: { id: user.id },
       },
     })
 
-    const idx = allUserReminders % emojis.length
+    const idx = reminderCount % emojis.length
 
     return this.db.reminder.create({
       data: {

--- a/src/reminders/reminders.service.ts
+++ b/src/reminders/reminders.service.ts
@@ -16,6 +16,11 @@ export class RemindersService {
   ) {}
 
   async create(user, data: Prisma.ReminderCreateInput): Promise<Reminder> {
+    const userInputNotificationTime = new Date(data.notificationTime)
+    const notificationHour =
+      `${userInputNotificationTime.getUTCHours()}`.padStart(2, '0')
+    const notificationMinutes =
+      `${userInputNotificationTime.getUTCMinutes()}`.padStart(2, '0')
     const allUserReminders = await this.db.reminder.count({
       where: {
         user: { id: user.id },
@@ -28,7 +33,9 @@ export class RemindersService {
       data: {
         ...data,
         emoji: emojis[idx],
-        notificationTime: new Date(data.notificationTime),
+        notificationTime: new Date(
+          `01/01/2001 ${notificationHour}:${notificationMinutes} UTC`
+        ),
         user: {
           connect: { id: user.id },
         },

--- a/src/reminders/reminders.service.ts
+++ b/src/reminders/reminders.service.ts
@@ -74,6 +74,7 @@ export class RemindersService {
   ): Promise<Reminder> {
     const reminder = await this.db.reminder.findUnique({ where })
     if (reminder.userId !== userId) return
+
     return this.db.reminder.delete({
       where: {
         id: where.id,

--- a/src/subscriptions/subscriptions.module.ts
+++ b/src/subscriptions/subscriptions.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common'
 import { SubscriptionsService } from './subscriptions.service'
 import { SubscriptionsController } from './subscriptions.controller'
 
-import { UsersModule } from 'src/users/users.module'
+import { UsersModule } from '../users/users.module'
 
 @Module({
   imports: [UsersModule],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common'
 
 import { UsersService } from './users.service'
 import { UsersController } from './users.controller'
-import { DatabaseModule } from 'src/database/database.module'
+import { DatabaseModule } from '../database/database.module'
 
 @Module({
   imports: [DatabaseModule],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common'
 
 import { Prisma, User } from '@prisma/client'
-import { DatabaseService } from 'src/database/database.service'
+import { DatabaseService } from '../database/database.service'
 
 @Injectable()
 export class UsersService {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,21 +1,21 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { Test, TestingModule } from '@nestjs/testing'
+import { INestApplication } from '@nestjs/common'
+import * as request from 'supertest'
+import { AppModule } from './../src/app.module'
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication;
+  let app: INestApplication
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    }).compile()
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
-  });
+    app = moduleFixture.createNestApplication()
+    await app.init()
+  })
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer()).get('/').expect(200).expect('OK');
-  });
-});
+    return request(app.getHttpServer()).get('/').expect(200).expect('OK')
+  })
+})

--- a/utils.ts
+++ b/utils.ts
@@ -1,17 +1,27 @@
+/**
+ *
+ * @param time : date object or iso string of date
+ * @returns : date object with utc hour and minutes with hard coded date
+ */
 export const getNotificationTime = (time: string | Date): Date => {
   const dateTime = new Date(time)
   const hour = `${dateTime.getUTCHours()}`.padStart(2, '0')
   const minutes = `${dateTime.getUTCMinutes()}`.padStart(2, '0')
   return new Date(`01/01/2001 ${hour}:${minutes} UTC`)
 }
+/**
+ *
+ * @param nextSendTime : Date of current time
+ * @param tries : number of tries message has already been sent, starts at 1
+ * @returns : a date object with just hour and minutes in UTC
+ * example: send 1st message => nextSend = now + 1, tries = 2
+ * send 2nd message => nextSend = now + 2, tries = 3
+ * send 3rd message => next Send = now + 3, tries = 4
+ * send 4th message => next Send = now + 24 tries = 5 active: false
+ */
 
 export const getNextSendTime = (nextSendTime: Date, tries: number): Date => {
   const sendTimeHours = (nextSendTime.getHours() + tries) % 24
   nextSendTime.setHours(sendTimeHours)
   return getNotificationTime(nextSendTime)
 }
-// tries = 1
-// message created: send 1st message => nextSend = now + 1, tries = 2
-// send 2nd message => nextSend = now + 2, tries = 3
-// send 3rd message => next Send = now + 3, tries = 4
-// send 4th message => next Send = now + 24 tries = 5 active: false

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,18 @@
+export const getNotificationTime = (time: string | Date): Date => {
+  const dateTime = new Date(time)
+  const hour = `${dateTime.getUTCHours()}`.padStart(2, '0')
+  const minutes = `${dateTime.getUTCMinutes()}`.padStart(2, '0')
+  return new Date(`01/01/2001 ${hour}:${minutes} UTC`)
+}
+
+export const getNextSendTime = (nextSendTime: Date, tries: number): Date => {
+  const offset = tries === 3 ? 24 : 1
+  const sendTimeHours = (nextSendTime.getHours() + tries + offset) % 24
+  nextSendTime.setHours(sendTimeHours)
+  return getNotificationTime(nextSendTime)
+}
+// tries = 0
+// message created: send 1st message => nextSend = now + 1, tries = 1
+// send 2nd message => nextSend = now + 2, tries = 2
+// send 3rd message => next Send = now + 3, tries = 3
+// send 4th message => next Send = now + 24 tries = 4

--- a/utils.ts
+++ b/utils.ts
@@ -6,13 +6,12 @@ export const getNotificationTime = (time: string | Date): Date => {
 }
 
 export const getNextSendTime = (nextSendTime: Date, tries: number): Date => {
-  const offset = tries === 3 ? 24 : 1
-  const sendTimeHours = (nextSendTime.getHours() + tries + offset) % 24
+  const sendTimeHours = (nextSendTime.getHours() + tries) % 24
   nextSendTime.setHours(sendTimeHours)
   return getNotificationTime(nextSendTime)
 }
-// tries = 0
-// message created: send 1st message => nextSend = now + 1, tries = 1
-// send 2nd message => nextSend = now + 2, tries = 2
-// send 3rd message => next Send = now + 3, tries = 3
-// send 4th message => next Send = now + 24 tries = 4
+// tries = 1
+// message created: send 1st message => nextSend = now + 1, tries = 2
+// send 2nd message => nextSend = now + 2, tries = 3
+// send 3rd message => next Send = now + 3, tries = 4
+// send 4th message => next Send = now + 24 tries = 5 active: false


### PR DESCRIPTION
This PR:

- [x] Fixes issue #16
- [x] Every reminder endpoint checks if userId matches with reminderId
- [x] Fixes issue #17 
- [x] Deletes messages older than 3 hrs