### PR TITLE
docs: add export reminder history to stretch goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Poke is a personal accountability system. You setup recurring goals on the platf
 
 - User can see dashboard summarizing their reminders
 - User can see data visualization of their streaks
+- User can export their reminder history


### PR DESCRIPTION
Adds 'User can export their reminder history' as a new item under Stretch goals in the README.